### PR TITLE
Release 1.2.0: extension install, template editing, request dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@ Thumbs.db
 __pycache__/
 *.pyc
 
-# Claude Code
-.claude/settings.local.json
+# AI tooling
+.claude/
+CLAUDE.md
+.cursor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable release changes for MCP Server for Joomla are recorded here.
 
+## 1.2.0 - 2026-06-20
+
+- Added **extension installation** support: a new `install_extension` MCP tool installs extensions onto the site.
+- Added **template editing** MCP tools: list installed templates, list and read template files, update template files, and create template overrides.
+- Fixed the client configuration snippet generation in the component dashboard view.
+- Fixed the Monolog log file path resolution.
+- Reordered the administrator menu items.
+- Updated the build script to also update the update.xml file.
+
 ## 1.1.0 - 2026-06-02
 
 - Added request metrics: every MCP request is recorded to a new `#__mcpserver_request_log` table (method, tool, status, error code, HTTP status, latency, client IP, context).

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Article versioning tools require Joomla article versioning to be enabled.
 | Tool | Description |
 |---|---|
 | `list_installed_templates` | List templates installed on the Joomla site (site and administrator clients) |
+| `install_extension` | Install a Joomla extension from a base64 zip or a download URL (arbitrary code execution — restrict to trusted callers) |
 
 ### Multilingual associations
 

--- a/admin/src/Service/MonologFactory.php
+++ b/admin/src/Service/MonologFactory.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Mcpserver\Administrator\Service;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Level;
@@ -23,7 +24,7 @@ class MonologFactory
     public static function createComponentLogger(string $channel = 'mcpserver', string $serverName = ''): Logger
     {
         $logger = new Logger($channel);
-        $handler = new StreamHandler(defined('JPATH_LOGS') ? JPATH_LOGS . '/com_mcpserver.log' : sys_get_temp_dir() . '/com_mcpserver.log', Level::Info);
+        $handler = new StreamHandler(self::resolveLogPath(), Level::Info);
         $handler->setFormatter(new JsonFormatter());
         $logger->pushHandler($handler);
 
@@ -35,6 +36,38 @@ class MonologFactory
         }
 
         return $logger;
+    }
+
+    /**
+     * Resolve the file Monolog should write to, preferring Joomla's configured
+     * log folder (the `log_path` global config), then the JPATH_LOGS constant,
+     * and only falling back to the system temp dir when neither is usable.
+     */
+    private static function resolveLogPath(): string
+    {
+        $candidates = [];
+
+        try {
+            $configured = (string) Factory::getApplication()->get('log_path');
+            if ($configured !== '') {
+                $candidates[] = $configured;
+            }
+        } catch (\Throwable $e) {
+            // Application not available (e.g. CLI bootstrap) — fall through.
+        }
+
+        if (defined('JPATH_LOGS')) {
+            $candidates[] = JPATH_LOGS;
+        }
+
+        foreach ($candidates as $dir) {
+            $dir = rtrim($dir, '/\\');
+            if (is_dir($dir) && is_writable($dir)) {
+                return $dir . '/com_mcpserver.log';
+            }
+        }
+
+        return sys_get_temp_dir() . '/com_mcpserver.log';
     }
 }
 

--- a/admin/src/Service/RpcService.php
+++ b/admin/src/Service/RpcService.php
@@ -93,6 +93,11 @@ class RpcService
             'update_template_style'         => fn(array $p) => $this->updateTemplateStyle($p),
             'delete_template_style'         => fn(array $p) => $this->deleteTemplateStyle($p),
             'list_installed_templates'      => fn(array $p) => $this->listInstalledTemplates($p),
+            'install_extension'             => fn(array $p) => $this->installExtension($p),
+            'list_template_files'           => fn(array $p) => $this->listTemplateFiles($p),
+            'get_template_file'             => fn(array $p) => $this->getTemplateFile($p),
+            'update_template_file'          => fn(array $p) => $this->updateTemplateFile($p),
+            'create_template_override'      => fn(array $p) => $this->createTemplateOverride($p),
             'list_article_associations'     => fn(array $p) => $this->listArticleAssociations($p),
             'set_article_associations'      => fn(array $p) => $this->setArticleAssociations($p),
             'list_menu_item_associations'   => fn(array $p) => $this->listMenuItemAssociations($p),
@@ -1466,6 +1471,406 @@ class RpcService
 
             return ['data' => $data];
         });
+    }
+
+    private function listTemplateFiles(array $params): array
+    {
+        $template = $this->resolveTemplate((int) ($params['extension_id'] ?? 0));
+        $media    = (bool) ($params['media'] ?? false);
+        $base     = $this->templateBasePath($template, $media);
+
+        if (!is_dir($base)) {
+            throw new \RuntimeException('Template directory not found: ' . $template->element);
+        }
+
+        $allowed = $this->templateAllowedFormats();
+        $files   = [];
+        $this->scanTemplateDir($base, '', $allowed, $files);
+        sort($files, SORT_NATURAL);
+
+        return [
+            'extension_id' => $template->extension_id,
+            'template'     => $template->element,
+            'client'       => $template->client_id === 0 ? 'site' : 'administrator',
+            'media'        => $media,
+            'files'        => $files,
+        ];
+    }
+
+    private function getTemplateFile(array $params): array
+    {
+        $template = $this->resolveTemplate((int) ($params['extension_id'] ?? 0));
+        $media    = (bool) ($params['media'] ?? false);
+        $relative = (string) ($params['path'] ?? '');
+
+        if ($relative === '') {
+            throw new \InvalidArgumentException('path is required');
+        }
+
+        $path = $this->safeTemplatePath($this->templateBasePath($template, $media), $relative);
+
+        if (!is_file($path)) {
+            throw new \InvalidArgumentException('File not found: ' . $relative);
+        }
+
+        if (!$this->templateExtensionAllowed($path)) {
+            throw new \InvalidArgumentException('File type is not editable: ' . $relative);
+        }
+
+        return [
+            'extension_id' => $template->extension_id,
+            'template'     => $template->element,
+            'path'         => $relative,
+            'source'       => (string) file_get_contents($path),
+        ];
+    }
+
+    private function updateTemplateFile(array $params): array
+    {
+        $template = $this->resolveTemplate((int) ($params['extension_id'] ?? 0));
+        $media    = (bool) ($params['media'] ?? false);
+        $relative = (string) ($params['path'] ?? '');
+
+        if ($relative === '' || !array_key_exists('source', $params)) {
+            throw new \InvalidArgumentException('path and source are required');
+        }
+
+        $path = $this->safeTemplatePath($this->templateBasePath($template, $media), $relative);
+
+        if (!is_file($path)) {
+            throw new \InvalidArgumentException('File not found (create an override first): ' . $relative);
+        }
+
+        if (!$this->templateExtensionAllowed($path)) {
+            throw new \InvalidArgumentException('File type is not editable: ' . $relative);
+        }
+
+        // Mirror Joomla's editor: normalise EOL to Unix and protect the asset manifest.
+        $source = str_replace(["\r\n", "\r"], "\n", (string) $params['source']);
+
+        if (str_ends_with($path, '/joomla.asset.json') && json_decode($source) === null) {
+            throw new \InvalidArgumentException('joomla.asset.json must contain valid JSON');
+        }
+
+        if (!is_writable($path) || file_put_contents($path, $source) === false) {
+            throw new \RuntimeException('Failed to write file (check permissions): ' . $relative);
+        }
+
+        return [
+            'extension_id'  => $template->extension_id,
+            'template'      => $template->element,
+            'path'          => $relative,
+            'bytes_written' => strlen($source),
+        ];
+    }
+
+    private function createTemplateOverride(array $params): array
+    {
+        $template = $this->resolveTemplate((int) ($params['extension_id'] ?? 0));
+        $source   = trim((string) ($params['source'] ?? ''), '/');
+
+        if ($source === '') {
+            throw new \InvalidArgumentException('source is required');
+        }
+
+        $allowedRoots = [
+            'components', 'modules', 'plugins', 'layouts',
+            'administrator/components', 'administrator/modules',
+        ];
+
+        $matched = false;
+        foreach ($allowedRoots as $root) {
+            if ($source === $root || str_starts_with($source, $root . '/')) {
+                $matched = true;
+                break;
+            }
+        }
+
+        if (!$matched || str_contains($source, '..')) {
+            throw new \InvalidArgumentException('source must point inside components/, modules/, plugins/ or layouts/');
+        }
+
+        $absolute = realpath(JPATH_ROOT . '/' . $source);
+        if ($absolute === false || !is_dir($absolute) || !str_starts_with($absolute, realpath(JPATH_ROOT) ?: JPATH_ROOT)) {
+            throw new \InvalidArgumentException('Override source folder not found: ' . $source);
+        }
+
+        $model = $this->bootTemplateModel($template->extension_id);
+
+        if (!$model->createOverride($absolute)) {
+            throw new \RuntimeException('Joomla could not create the override for: ' . $source);
+        }
+
+        return [
+            'extension_id' => $template->extension_id,
+            'template'     => $template->element,
+            'source'       => $source,
+            'created'      => true,
+        ];
+    }
+
+    /**
+     * Load a template extension row (type=template) by extension_id.
+     */
+    private function resolveTemplate(int $extensionId): object
+    {
+        if ($extensionId <= 0) {
+            throw new \InvalidArgumentException('extension_id is required');
+        }
+
+        $db    = Factory::getDbo();
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['extension_id', 'element', 'client_id']))
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('extension_id') . ' = ' . $extensionId)
+            ->where($db->quoteName('type') . ' = ' . $db->quote('template'));
+
+        $row = $db->setQuery($query)->loadObject();
+
+        if (!$row) {
+            throw new \InvalidArgumentException('Template ' . $extensionId . ' not found');
+        }
+
+        $row->extension_id = (int) $row->extension_id;
+        $row->client_id    = (int) $row->client_id;
+
+        return $row;
+    }
+
+    private function templateBasePath(object $template, bool $media): string
+    {
+        if ($media) {
+            return JPATH_ROOT . '/media/templates/'
+                . ($template->client_id === 0 ? 'site' : 'administrator')
+                . '/' . $template->element;
+        }
+
+        return JPATH_ROOT . '/'
+            . ($template->client_id === 0 ? '' : 'administrator/')
+            . 'templates/' . $template->element;
+    }
+
+    /**
+     * Resolve a template-root-relative path to an absolute path, refusing any
+     * traversal outside the template directory.
+     */
+    private function safeTemplatePath(string $base, string $relative): string
+    {
+        $relative = str_replace('\\', '/', $relative);
+
+        if (str_contains($relative, '..') || str_contains($relative, "\0")) {
+            throw new \InvalidArgumentException('Invalid path');
+        }
+
+        $path     = rtrim($base, '/') . '/' . ltrim($relative, '/');
+        $realBase = realpath($base) ?: $base;
+        $parent   = realpath(\dirname($path));
+
+        if ($parent === false || ($parent !== $realBase && !str_starts_with($parent, $realBase . '/'))) {
+            throw new \InvalidArgumentException('Path is outside the template directory');
+        }
+
+        return $path;
+    }
+
+    /**
+     * Recursively collect editable files as paths relative to the template root.
+     */
+    private function scanTemplateDir(string $base, string $prefix, array $allowed, array &$files): void
+    {
+        $dir = $prefix === '' ? $base : $base . '/' . $prefix;
+
+        foreach (scandir($dir) ?: [] as $entry) {
+            if (\in_array($entry, ['.', '..', 'node_modules'], true)) {
+                continue;
+            }
+
+            $relative = $prefix === '' ? $entry : $prefix . '/' . $entry;
+
+            if (is_dir($dir . '/' . $entry)) {
+                $this->scanTemplateDir($base, $relative, $allowed, $files);
+                continue;
+            }
+
+            $ext = strtolower(pathinfo($entry, PATHINFO_EXTENSION));
+            if (\in_array($ext, $allowed, true)) {
+                $files[] = $relative;
+            }
+        }
+    }
+
+    /**
+     * Editable extensions, mirroring com_templates' allowed formats so the tool
+     * exposes exactly what the Joomla "Customise" editor does.
+     *
+     * @return array<int,string>
+     */
+    private function templateAllowedFormats(): array
+    {
+        $params = \Joomla\CMS\Component\ComponentHelper::getParams('com_templates');
+        $list   = implode(',', [
+            $params->get('source_formats', 'txt,less,ini,xml,js,php,css,scss,sass,json'),
+            $params->get('image_formats', 'gif,bmp,jpg,jpeg,png,webp'),
+            $params->get('font_formats', 'woff,woff2,ttf,otf'),
+            $params->get('compressed_formats', 'zip'),
+        ]);
+
+        return array_map('strtolower', array_filter(array_map('trim', explode(',', $list))));
+    }
+
+    private function templateExtensionAllowed(string $path): bool
+    {
+        return \in_array(strtolower(pathinfo($path, PATHINFO_EXTENSION)), $this->templateAllowedFormats(), true);
+    }
+
+    /**
+     * Boot the com_templates TemplateModel for override creation. The model
+     * reads its template id from the request input, so we seed it there (an
+     * integer survives Joomla's input filtering) and on the model state.
+     */
+    private function bootTemplateModel(int $extensionId): object
+    {
+        $app = Factory::getApplication();
+        $app->getInput()->set('id', $extensionId);
+
+        $model = $app->bootComponent('com_templates')
+            ->getMVCFactory()
+            ->createModel('Template', 'Administrator', ['ignore_request' => true]);
+
+        if ($model === false) {
+            throw new \RuntimeException('Unable to load the Joomla template model');
+        }
+
+        $model->setState('extension.id', $extensionId);
+
+        return $model;
+    }
+
+    private function installExtension(array $params): array
+    {
+        $bytes = $this->resolveExtensionPackageBytes($params);
+
+        $tmpPath = (string) Factory::getApplication()->get('tmp_path');
+        if ($tmpPath === '' || !is_dir($tmpPath) || !is_writable($tmpPath)) {
+            throw new \RuntimeException('Joomla tmp_path is not writable');
+        }
+
+        $tmpFile = rtrim($tmpPath, '/') . '/mcp-install-' . bin2hex(random_bytes(8)) . '.zip';
+        if (file_put_contents($tmpFile, $bytes) === false) {
+            throw new \RuntimeException('Failed to write package to tmp_path');
+        }
+
+        // Validate ZIP integrity before handing off to Joomla's installer. Joomla's archive layer
+        // (libraries/vendor/joomla/archive Zip.php) walks the central directory with computed
+        // offsets; a truncated or structurally corrupt package overshoots the buffer and, on PHP 8,
+        // dies with a bare "Undefined array key" warning followed by a ValueError from strpos()
+        // ("Argument #3 ($offset) must be contained in argument #1 ($haystack)") — which we can only
+        // re-wrap as an opaque JSON-RPC -32603. A consistency check here turns that into a clear,
+        // actionable message. The signature alone is not enough: the bad payloads start with a valid
+        // ZIP header and only break deeper in, so use ZipArchive::CHECKCONS when ext-zip is available.
+        if (class_exists(\ZipArchive::class)) {
+            $za     = new \ZipArchive();
+            $opened = $za->open($tmpFile, \ZipArchive::CHECKCONS);
+            if ($opened === true) {
+                $za->close();
+            } else {
+                @unlink($tmpFile);
+                throw new \InvalidArgumentException(
+                    'Package is not a valid ZIP archive (consistency check failed, code ' . (int) $opened . ') — '
+                    . 'the download may be truncated/corrupt or the content is not a Joomla extension package'
+                );
+            }
+        } elseif (strncmp($bytes, "PK\x03\x04", 4) !== 0 && strncmp($bytes, "PK\x05\x06", 4) !== 0) {
+            @unlink($tmpFile);
+            throw new \InvalidArgumentException(
+                'Package is not a valid ZIP archive (missing ZIP signature) — '
+                . 'the download may be truncated/corrupt or the content is not a Joomla extension package'
+            );
+        }
+
+        $package = null;
+        try {
+            try {
+                $package = \Joomla\CMS\Installer\InstallerHelper::unpack($tmpFile, true);
+            } catch (\Throwable $e) {
+                // The integrity check above catches the common corrupt/truncated case; anything that
+                // still throws out of the core unpacker is unexpected, so preserve file:line for
+                // diagnosis instead of surfacing only the bare message via JSON-RPC -32603.
+                $this->logger->error('Extension unpack failed', [
+                    'error' => $e->getMessage(),
+                    'where' => $e->getFile() . ':' . $e->getLine(),
+                ]);
+                throw new \RuntimeException(
+                    'Failed to unpack extension package: ' . $e->getMessage()
+                    . ' (' . $e->getFile() . ':' . $e->getLine() . ')',
+                    0,
+                    $e
+                );
+            }
+            if (!is_array($package) || empty($package['type']) || empty($package['dir'])) {
+                throw new \RuntimeException('Unable to detect extension type — package may be corrupt or not a Joomla extension');
+            }
+
+            $app = Factory::getApplication();
+            $app->getMessageQueue(true); // flush any pre-existing messages
+
+            $installer = \Joomla\CMS\Installer\Installer::getInstance();
+            $ok = (bool) $installer->install($package['dir']);
+
+            $messages = array_map(
+                static fn ($m) => ['type' => (string) ($m['type'] ?? 'message'), 'text' => (string) ($m['message'] ?? '')],
+                $app->getMessageQueue(true)
+            );
+
+            if (!$ok) {
+                $reason = $messages[0]['text'] ?? 'Installer reported failure without a message';
+                throw new \RuntimeException('Extension install failed: ' . $reason);
+            }
+
+            $this->cache->deleteByPrefix('installed_templates:');
+            $this->cache->deleteByPrefix('installed_languages:');
+
+            return [
+                'data' => [
+                    'success'  => true,
+                    'type'     => (string) $package['type'],
+                    'manifest' => $installer->manifest instanceof \SimpleXMLElement
+                        ? (string) ($installer->manifest->name ?? '')
+                        : null,
+                    'messages' => $messages,
+                ],
+            ];
+        } finally {
+            if ($package !== null) {
+                \Joomla\CMS\Installer\InstallerHelper::cleanupInstall($package['packagefile'] ?? $tmpFile, $package['extractdir'] ?? ($package['dir'] ?? ''));
+            } elseif (is_file($tmpFile)) {
+                @unlink($tmpFile);
+            }
+        }
+    }
+
+    private function resolveExtensionPackageBytes(array $params): string
+    {
+        $hasContent = isset($params['content']) && $params['content'] !== '';
+        $hasUrl     = isset($params['source_url']) && $params['source_url'] !== '';
+
+        if ($hasContent && $hasUrl) {
+            throw new \InvalidArgumentException('Provide either content or source_url, not both');
+        }
+
+        if ($hasContent) {
+            $bytes = base64_decode((string) $params['content'], true);
+            if ($bytes === false) {
+                throw new \InvalidArgumentException('content is not valid base64');
+            }
+            return $bytes;
+        }
+
+        if ($hasUrl) {
+            return $this->rest->fetchUrlContent((string) $params['source_url']);
+        }
+
+        throw new \InvalidArgumentException('Either content or source_url is required');
     }
 
     private function listArticleAssociations(array $params): array

--- a/admin/src/Service/ToolRegistry.php
+++ b/admin/src/Service/ToolRegistry.php
@@ -1023,6 +1023,25 @@ class ToolRegistry
         ]);
 
         $this->register([
+            'name' => 'install_extension',
+            'description' => 'Install a Joomla extension from a zip package. Provide either base64 `content` or a `source_url` that the server will download. WARNING: this is arbitrary code execution — only allow trusted callers.',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'content' => ['type' => 'string', 'description' => 'Base64-encoded contents of the .zip package'],
+                    'source_url' => ['type' => 'string', 'description' => 'URL the server will download (server fetches bytes itself; no client redirect)'],
+                ],
+            ],
+            'annotations' => [
+                'title' => 'Install Extension',
+                'readOnlyHint' => false,
+                'destructiveHint' => true,
+                'idempotentHint' => false,
+                'openWorldHint' => true,
+            ],
+        ]);
+
+        $this->register([
             'name' => 'list_installed_templates',
             'description' => 'List templates installed on the Joomla site (both site and administrator clients). Read-only view of `#__extensions` filtered to type=template.',
             'inputSchema' => [
@@ -1039,6 +1058,110 @@ class ToolRegistry
                 'title' => 'List Installed Templates',
                 'readOnlyHint' => true,
                 'idempotentHint' => true,
+                'openWorldHint' => true,
+            ],
+        ]);
+
+        $this->register([
+            'name' => 'list_template_files',
+            'description' => 'List the editable source files of an installed template (the "Customise" view of Joomla\'s template manager). '
+                . 'Use `extension_id` from list_installed_templates. Returns file paths relative to the template root (e.g. "index.php", '
+                . '"css/template.css", "html/com_content/article/default.php"). Set `media` to true to list the template\'s media folder instead.',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'extension_id' => ['type' => 'integer', 'description' => 'Template extension ID (from list_installed_templates)'],
+                    'media' => [
+                        'type' => 'boolean',
+                        'default' => false,
+                        'description' => 'List the media/templates folder instead of the template folder',
+                    ],
+                ],
+                'required' => ['extension_id'],
+            ],
+            'annotations' => [
+                'title' => 'List Template Files',
+                'readOnlyHint' => true,
+                'idempotentHint' => true,
+                'openWorldHint' => true,
+            ],
+        ]);
+
+        $this->register([
+            'name' => 'get_template_file',
+            'description' => 'Read the source of a single template file. `path` is relative to the template root, as returned by '
+                . 'list_template_files (e.g. "html/com_content/article/default.php"). Set `media` to true to read from the template\'s media folder.',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'extension_id' => ['type' => 'integer', 'description' => 'Template extension ID'],
+                    'path' => ['type' => 'string', 'description' => 'File path relative to the template root'],
+                    'media' => [
+                        'type' => 'boolean',
+                        'default' => false,
+                        'description' => 'Read from the media/templates folder instead',
+                    ],
+                ],
+                'required' => ['extension_id', 'path'],
+            ],
+            'annotations' => [
+                'title' => 'Get Template File',
+                'readOnlyHint' => true,
+                'idempotentHint' => true,
+                'openWorldHint' => true,
+            ],
+        ]);
+
+        $this->register([
+            'name' => 'update_template_file',
+            'description' => 'Overwrite the source of an existing template file (Joomla\'s template "Customise" editor). The file must already '
+                . 'exist; create overrides with create_template_override first. Line endings are normalised to Unix, and joomla.asset.json '
+                . 'must remain valid JSON. `path` is relative to the template root.',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'extension_id' => ['type' => 'integer', 'description' => 'Template extension ID'],
+                    'path' => ['type' => 'string', 'description' => 'File path relative to the template root'],
+                    'source' => ['type' => 'string', 'description' => 'The complete new file contents'],
+                    'media' => [
+                        'type' => 'boolean',
+                        'default' => false,
+                        'description' => 'Write to the media/templates folder instead',
+                    ],
+                ],
+                'required' => ['extension_id', 'path', 'source'],
+            ],
+            'annotations' => [
+                'title' => 'Update Template File',
+                'readOnlyHint' => false,
+                'destructiveHint' => true,
+                'idempotentHint' => true,
+                'openWorldHint' => true,
+            ],
+        ]);
+
+        $this->register([
+            'name' => 'create_template_override',
+            'description' => 'Create a template override by copying a core component view, module, plugin or layout into the template\'s html/ folder, '
+                . 'exactly as Joomla\'s "Create Overrides" tab does. `source` is the folder to override, relative to the Joomla root, e.g. '
+                . '"components/com_content/tmpl/article" (a component view), "modules/mod_menu" (a module), "layouts/joomla/content" (a layout) '
+                . 'or "plugins/system/example". After creating the override, use list_template_files / get_template_file / update_template_file to edit it.',
+            'inputSchema' => [
+                'type' => 'object',
+                'properties' => [
+                    'extension_id' => ['type' => 'integer', 'description' => 'Template extension ID that will receive the override'],
+                    'source' => [
+                        'type' => 'string',
+                        'description' => 'Folder to override, relative to the Joomla root (e.g. "components/com_content/tmpl/article", "modules/mod_menu", "layouts/joomla/content")',
+                    ],
+                ],
+                'required' => ['extension_id', 'source'],
+            ],
+            'annotations' => [
+                'title' => 'Create Template Override',
+                'readOnlyHint' => false,
+                'destructiveHint' => false,
+                'idempotentHint' => false,
                 'openWorldHint' => true,
             ],
         ]);

--- a/admin/src/View/Mcpcomponent/HtmlView.php
+++ b/admin/src/View/Mcpcomponent/HtmlView.php
@@ -71,30 +71,29 @@ class HtmlView extends BaseHtmlView
         $token = (string) $params->get('mcp_bearer_token', '');
         
         $args = [
-            '-s',
-            '-X',
-            'POST',
+            '-y',
+            'mcp-remote',
             $rpcUrl,
-            '-H',
-            'Content-Type: application/json'
         ];
 
-        if ($params->get('require_auth', 0) && $token !== '') {
-            $args[] = '-H';
-            $args[] = 'Authorization: Bearer <YOUR_TOKEN>';
-        }
+        $server = [
+            'command' => 'npx',
+            'args' => $args,
+        ];
 
-        // Add the -d @- to read from stdin for MCP stdio transport
-        $args[] = '-d';
-        $args[] = '@-';
+        // Pass the bearer token through an env var so it stays out of the args list.
+        if ($params->get('require_auth', 0) && $token !== '') {
+            $server['args'][] = '--header';
+            $server['args'][] = 'Authorization:${AUTH_HEADER}';
+            $server['env'] = [
+                'AUTH_HEADER' => 'Bearer <YOUR_TOKEN>',
+            ];
+        }
 
         $config = [
             'mcpServers' => [
-                'joomla' => [
-                    'command' => 'curl',
-                    'args' => $args
-                ]
-            ]
+                'joomla' => $server,
+            ],
         ];
 
         $maskedToken = '';

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,38 @@ if [[ -f "$README_PATH" ]]; then
     fi
 fi
 
+# Sync the Joomla updater feed: prepend an <update> entry for this version
+# (newest first) if one isn't already present. mcpserver.xml stays the source
+# of truth; Joomla offers the highest version whose targetplatform/php match.
+UPDATE_PATH="$SCRIPT_DIR/update.xml"
+if [[ -f "$UPDATE_PATH" ]]; then
+    if grep -q "<version>${VERSION}</version>" "$UPDATE_PATH"; then
+        echo "update.xml already lists v${VERSION}"
+    else
+        ENTRY_FILE=$(mktemp)
+        cat > "$ENTRY_FILE" <<EOF
+    <update>
+        <name>MCP Server for Joomla</name>
+        <description>Model Context Protocol server component for Joomla</description>
+        <element>com_mcpserver</element>
+        <type>component</type>
+        <client>administrator</client>
+        <version>${VERSION}</version>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v${VERSION}/com_mcpserver-${VERSION}.zip</downloadurl>
+        </downloads>
+        <targetplatform name="joomla" version="((4\.)|(5\.)|(6\.))" />
+        <php_minimum>8.1</php_minimum>
+        <maintainer>Onepoint Consulting Ltd</maintainer>
+        <maintainerurl>https://github.com/OnepointConsultingLtd/joomla-mcp-server</maintainerurl>
+    </update>
+EOF
+        sed -i "/<updates>/r $ENTRY_FILE" "$UPDATE_PATH"
+        rm -f "$ENTRY_FILE"
+        echo "Added update.xml entry for v${VERSION}"
+    fi
+fi
+
 # Clean previous build
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"

--- a/mcpserver.xml
+++ b/mcpserver.xml
@@ -45,8 +45,8 @@
         <namespace path="src">Joomla\Component\Mcpserver</namespace>
         <menu>MCP Server for Joomla</menu>
         <submenu>
-            <menu link="option=com_mcpserver">Options</menu>
             <menu link="option=com_mcpserver&amp;view=dashboard">COM_MCPSERVER_SUBMENU_DASHBOARD</menu>
+            <menu link="option=com_mcpserver">Options</menu>
         </submenu>
         <languages folder="admin/language">
             <language tag="en-GB">en-GB/en-GB.com_mcpserver.ini</language>

--- a/mcpserver.xml
+++ b/mcpserver.xml
@@ -6,7 +6,7 @@
     <authorEmail>allan@onepointltd.com</authorEmail>
     <copyright>Copyright (C) 2026 Onepoint Consulting Ltd</copyright>
     <creationDate>2025-08-13</creationDate>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <license>GPL-2.0-or-later</license>
     <description>Model Context Protocol server component for Joomla</description>
     <element>com_mcpserver</element>

--- a/update.xml
+++ b/update.xml
@@ -6,6 +6,36 @@
         <element>com_mcpserver</element>
         <type>component</type>
         <client>administrator</client>
+        <version>1.2.0</version>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.2.0/com_mcpserver-1.2.0.zip</downloadurl>
+        </downloads>
+        <targetplatform name="joomla" version="((4\.)|(5\.)|(6\.))" />
+        <php_minimum>8.1</php_minimum>
+        <maintainer>Onepoint Consulting Ltd</maintainer>
+        <maintainerurl>https://github.com/OnepointConsultingLtd/joomla-mcp-server</maintainerurl>
+    </update>
+    <update>
+        <name>MCP Server for Joomla</name>
+        <description>Model Context Protocol server component for Joomla</description>
+        <element>com_mcpserver</element>
+        <type>component</type>
+        <client>administrator</client>
+        <version>1.1.0</version>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.1.0/com_mcpserver-1.1.0.zip</downloadurl>
+        </downloads>
+        <targetplatform name="joomla" version="((4\.)|(5\.)|(6\.))" />
+        <php_minimum>8.1</php_minimum>
+        <maintainer>Onepoint Consulting Ltd</maintainer>
+        <maintainerurl>https://github.com/OnepointConsultingLtd/joomla-mcp-server</maintainerurl>
+    </update>
+    <update>
+        <name>MCP Server for Joomla</name>
+        <description>Model Context Protocol server component for Joomla</description>
+        <element>com_mcpserver</element>
+        <type>component</type>
+        <client>administrator</client>
         <version>1.0.0</version>
         <downloads>
             <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.0.0/com_mcpserver-1.0.0.zip</downloadurl>


### PR DESCRIPTION
## Summary

  **New MCP tools**
  - `install_extension` — install extensions onto the site
  - Template editing: `list_installed_templates`, `list_template_files`, `get_template_file`, `update_template_file`, `create_template_override`

  **Fixes & build**
  - Fixed log file path resolution
  - Fixed client configuration snippet generation in the dashboard view
  - Reordered administrator menu items
  - `build.sh` now also rewrites `update.xml` at build time
