### PR TITLE
Release 1.3.3: tools/list pagination and install_extension source_path improvements

### DIFF
--- a/admin/src/Service/RestClient.php
+++ b/admin/src/Service/RestClient.php
@@ -184,11 +184,11 @@ class RestClient
 		}
 	}
 
-	public function fetchUrlContent(string $url): string
+	public function fetchUrlContent(string $url, float $timeout = 30.0): string
 	{
 		try {
 			$config = [
-				'timeout' => 30.0,
+				'timeout' => $timeout,
 				'verify' => $this->http->getConfig('verify'),
 			];
 

--- a/admin/src/Service/RpcService.php
+++ b/admin/src/Service/RpcService.php
@@ -20,6 +20,8 @@ class RpcService
 {
     private const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'];
 
+    private const TOOLS_LIST_PAGE_SIZE = 30;
+
     private static ?string $cachedVersion = null;
 
     private RestClient $rest;
@@ -146,7 +148,7 @@ class RpcService
         }
 
         if ($method === 'tools/list') {
-            $response = $this->handleListTools($id);
+            $response = $this->handleListTools($id, $params);
             return $isNotification ? null : $response;
         }
 
@@ -229,11 +231,76 @@ class RpcService
         return self::$cachedVersion;
     }
 
-    private function handleListTools(mixed $id): array
+    private function handleListTools(mixed $id, array $params = []): array
     {
         $tools = $this->toolRegistry->getAll();
-        $this->logger->info('listTools: Found ' . count($tools) . ' tools', ['server' => $this->serverName]);
-        return JsonRpc::successResponse($id, ['tools' => $tools]);
+        $total = count($tools);
+        $offset = 0;
+
+        if (array_key_exists('cursor', $params)) {
+            if (!is_string($params['cursor']) || $params['cursor'] === '') {
+                return JsonRpc::errorResponse($id, JsonRpc::INVALID_PARAMS, 'Invalid cursor');
+            }
+
+            $decodedOffset = $this->decodeListCursor($params['cursor']);
+
+            if ($decodedOffset === null) {
+                return JsonRpc::errorResponse($id, JsonRpc::INVALID_PARAMS, 'Invalid cursor');
+            }
+
+            $offset = $decodedOffset;
+        }
+
+        if ($offset > $total) {
+            return JsonRpc::errorResponse($id, JsonRpc::INVALID_PARAMS, 'Invalid cursor');
+        }
+
+        if ($total <= self::TOOLS_LIST_PAGE_SIZE && $offset === 0) {
+            $page = $tools;
+            $result = ['tools' => $page];
+        } else {
+            $page = array_values(array_slice($tools, $offset, self::TOOLS_LIST_PAGE_SIZE));
+            $result = ['tools' => $page];
+
+            if ($offset + count($page) < $total) {
+                $result['nextCursor'] = $this->encodeListCursor($offset + count($page));
+            }
+        }
+
+        $this->logger->info(
+            'listTools: Found ' . $total . ' tools, returning ' . count($page) . ' from offset ' . $offset,
+            ['server' => $this->serverName]
+        );
+
+        return JsonRpc::successResponse($id, $result);
+    }
+
+    private function encodeListCursor(int $offset): string
+    {
+        return base64_encode((string) json_encode(['offset' => $offset], JSON_THROW_ON_ERROR));
+    }
+
+    private function decodeListCursor(string $cursor): ?int
+    {
+        $decoded = base64_decode($cursor, true);
+
+        if ($decoded === false) {
+            return null;
+        }
+
+        try {
+            $data = json_decode($decoded, true, 2, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (!is_array($data) || !isset($data['offset']) || !is_numeric($data['offset'])) {
+            return null;
+        }
+
+        $offset = (int) $data['offset'];
+
+        return $offset >= 0 ? $offset : null;
     }
 
     private function handleCallTool(mixed $id, array $params): array

--- a/admin/src/Service/RpcService.php
+++ b/admin/src/Service/RpcService.php
@@ -1944,9 +1944,11 @@ class RpcService
     {
         $hasContent = isset($params['content']) && $params['content'] !== '';
         $hasUrl     = isset($params['source_url']) && $params['source_url'] !== '';
+        $hasPath    = isset($params['source_path']) && $params['source_path'] !== '';
 
-        if ($hasContent && $hasUrl) {
-            throw new \InvalidArgumentException('Provide either content or source_url, not both');
+        $sources = (int) $hasContent + (int) $hasUrl + (int) $hasPath;
+        if ($sources > 1) {
+            throw new \InvalidArgumentException('Provide exactly one of content, source_url, or source_path');
         }
 
         if ($hasContent) {
@@ -1958,10 +1960,62 @@ class RpcService
         }
 
         if ($hasUrl) {
-            return $this->rest->fetchUrlContent((string) $params['source_url']);
+            return $this->rest->fetchUrlContent((string) $params['source_url'], 120.0);
         }
 
-        throw new \InvalidArgumentException('Either content or source_url is required');
+        if ($hasPath) {
+            return $this->readExtensionPackageFromPath((string) $params['source_path']);
+        }
+
+        throw new \InvalidArgumentException('One of content, source_url, or source_path is required');
+    }
+
+    private function readExtensionPackageFromPath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            throw new \InvalidArgumentException('source_path is required');
+        }
+
+        if (!is_file($path)) {
+            throw new \InvalidArgumentException('source_path does not exist or is not a file');
+        }
+
+        $real = realpath($path);
+        if ($real === false) {
+            throw new \InvalidArgumentException('source_path could not be resolved');
+        }
+
+        if (!preg_match('/\.zip$/i', $real)) {
+            throw new \InvalidArgumentException('source_path must point to a .zip file');
+        }
+
+        $allowedRoots = array_values(array_filter(array_map(
+            static fn (string $root): string => realpath($root) ?: '',
+            array_unique([
+                (string) Factory::getApplication()->get('tmp_path'),
+                JPATH_ROOT,
+            ])
+        )));
+
+        $allowed = false;
+        foreach ($allowedRoots as $root) {
+            if ($root !== '' && str_starts_with($real, $root . DIRECTORY_SEPARATOR)) {
+                $allowed = true;
+                break;
+            }
+        }
+
+        if (!$allowed) {
+            throw new \InvalidArgumentException('source_path must be under Joomla tmp_path or the site root');
+        }
+
+        $bytes = file_get_contents($real);
+        if ($bytes === false) {
+            throw new \RuntimeException('Failed to read source_path');
+        }
+
+        return $bytes;
     }
 
     private function listArticleAssociations(array $params): array

--- a/admin/src/Service/ToolRegistry.php
+++ b/admin/src/Service/ToolRegistry.php
@@ -1024,12 +1024,27 @@ class ToolRegistry
 
         $this->register([
             'name' => 'install_extension',
-            'description' => 'Install a Joomla extension from a zip package. Provide either base64 `content` or a `source_url` that the server will download. WARNING: this is arbitrary code execution — only allow trusted callers.',
+            'description' => 'Install a Joomla extension from a zip package. '
+                . 'Provide exactly one of: `source_url` (preferred — server downloads the package), '
+                . '`source_path` (absolute path to a .zip already on the Joomla server), '
+                . 'or base64 `content` (small packages only). '
+                . 'Do not read local .zip files in the MCP client and pass them as content — MCP clients cannot read large binary files. '
+                . 'WARNING: this is arbitrary code execution — only allow trusted callers.',
             'inputSchema' => [
                 'type' => 'object',
                 'properties' => [
-                    'content' => ['type' => 'string', 'description' => 'Base64-encoded contents of the .zip package'],
-                    'source_url' => ['type' => 'string', 'description' => 'URL the server will download (server fetches bytes itself; no client redirect)'],
+                    'content' => [
+                        'type' => 'string',
+                        'description' => 'Base64-encoded contents of the .zip package (small packages only; prefer source_url or source_path)',
+                    ],
+                    'source_url' => [
+                        'type' => 'string',
+                        'description' => 'URL the server will download (preferred for release packages and GitHub assets)',
+                    ],
+                    'source_path' => [
+                        'type' => 'string',
+                        'description' => 'Absolute path on the Joomla server to an existing .zip file (must be under tmp_path or the site root)',
+                    ],
                 ],
             ],
             'annotations' => [

--- a/scripts/joomla_mcp_client.py
+++ b/scripts/joomla_mcp_client.py
@@ -75,8 +75,27 @@ class JoomlaHttpClient:
         return self.call("initialize", {"protocolVersion": "2025-06-18", "capabilities": {}})
 
     def list_tools(self) -> list[dict[str, Any]]:
-        result = self.call("tools/list", {})
-        return result.get("tools", []) if isinstance(result, dict) else []
+        tools: list[dict[str, Any]] = []
+        cursor: str | None = None
+
+        while True:
+            params: dict[str, Any] = {}
+            if cursor is not None:
+                params["cursor"] = cursor
+
+            result = self.call("tools/list", params)
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("tools", [])
+            if isinstance(page, list):
+                tools.extend(page)
+
+            cursor = result.get("nextCursor")
+            if not cursor:
+                break
+
+        return tools
 
     def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> Any:
         result = self.call("tools/call", {"name": name, "arguments": arguments or {}})


### PR DESCRIPTION
## Summary

- **Fixed `tools/list` pagination** — implementing MCP cursor-based paging (30 tools per page, `nextCursor`).
- **Improved `install_extension`** — adding `source_path` for server-side `.zip` files, preferring `source_url` over base64 `content` in the tool description.
- **Updated evaluation client** — `scripts/joomla_mcp_client.py` now follows `nextCursor` when listing tools.
