### PR TITLE
Release 1.3.3: tools/list pagination and install_extension source_path improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate tag matches manifest version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          MANIFEST_VERSION="$(grep -oP '<version>\K[^<]+' mcpserver.xml)"
+          if [[ "$TAG_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "::error::Git tag v${TAG_VERSION} does not match mcpserver.xml version ${MANIFEST_VERSION}."
+            echo "Bump <version> in mcpserver.xml, add a ## ${TAG_VERSION} section to CHANGELOG.md, commit, then create the tag on that commit."
+            exit 1
+          fi
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable release changes for MCP Server for Joomla are recorded here.
 
+## 1.3.3 - 2026-06-29
+
+- Fixed tools listing pagination.
+- Updated `install_extension` tool description to prefer source path over base64 content.
+
 ## 1.3.2 - 2026-06-23
 
 - Added SHA-256 checksum verification for release packages: the release workflow now records the package hash in `update.xml` so Joomla can validate downloaded updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable release changes for MCP Server for Joomla are recorded here.
 
+## 1.3.2 - 2026-06-23
+
+- Added SHA-256 checksum verification for release packages: the release workflow now records the package hash in `update.xml` so Joomla can validate downloaded updates.
+- Fixed paging issues with broken offset value as well as a wrong total_count.
+- Added evaluations for paging.
+
 ## 1.3.1 - 2026-06-22
 
 - Improved tool execution failures and policy denials handling.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Joomla 4, 5 and 6 component that exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server over HTTP JSON-RPC. It lets MCP clients such as Claude Desktop and Cursor work with Joomla content through the site's own Joomla Web Services API.
 
-**Version:** 1.3.1 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
+**Version:** 1.3.2 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Joomla 4, 5 and 6 component that exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server over HTTP JSON-RPC. It lets MCP clients such as Claude Desktop and Cursor work with Joomla content through the site's own Joomla Web Services API.
 
-**Version:** 1.3.2 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
+**Version:** 1.3.3 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
 
 ## Features
 

--- a/admin/src/Service/RestClient.php
+++ b/admin/src/Service/RestClient.php
@@ -184,11 +184,11 @@ class RestClient
 		}
 	}
 
-	public function fetchUrlContent(string $url): string
+	public function fetchUrlContent(string $url, float $timeout = 30.0): string
 	{
 		try {
 			$config = [
-				'timeout' => 30.0,
+				'timeout' => $timeout,
 				'verify' => $this->http->getConfig('verify'),
 			];
 

--- a/admin/src/Service/RpcService.php
+++ b/admin/src/Service/RpcService.php
@@ -20,6 +20,8 @@ class RpcService
 {
     private const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'];
 
+    private const TOOLS_LIST_PAGE_SIZE = 30;
+
     private static ?string $cachedVersion = null;
 
     private RestClient $rest;
@@ -146,7 +148,7 @@ class RpcService
         }
 
         if ($method === 'tools/list') {
-            $response = $this->handleListTools($id);
+            $response = $this->handleListTools($id, $params);
             return $isNotification ? null : $response;
         }
 
@@ -229,11 +231,76 @@ class RpcService
         return self::$cachedVersion;
     }
 
-    private function handleListTools(mixed $id): array
+    private function handleListTools(mixed $id, array $params = []): array
     {
         $tools = $this->toolRegistry->getAll();
-        $this->logger->info('listTools: Found ' . count($tools) . ' tools', ['server' => $this->serverName]);
-        return JsonRpc::successResponse($id, ['tools' => $tools]);
+        $total = count($tools);
+        $offset = 0;
+
+        if (array_key_exists('cursor', $params)) {
+            if (!is_string($params['cursor']) || $params['cursor'] === '') {
+                return JsonRpc::errorResponse($id, JsonRpc::INVALID_PARAMS, 'Invalid cursor');
+            }
+
+            $decodedOffset = $this->decodeListCursor($params['cursor']);
+
+            if ($decodedOffset === null) {
+                return JsonRpc::errorResponse($id, JsonRpc::INVALID_PARAMS, 'Invalid cursor');
+            }
+
+            $offset = $decodedOffset;
+        }
+
+        if ($offset > $total) {
+            return JsonRpc::errorResponse($id, JsonRpc::INVALID_PARAMS, 'Invalid cursor');
+        }
+
+        if ($total <= self::TOOLS_LIST_PAGE_SIZE && $offset === 0) {
+            $page = $tools;
+            $result = ['tools' => $page];
+        } else {
+            $page = array_values(array_slice($tools, $offset, self::TOOLS_LIST_PAGE_SIZE));
+            $result = ['tools' => $page];
+
+            if ($offset + count($page) < $total) {
+                $result['nextCursor'] = $this->encodeListCursor($offset + count($page));
+            }
+        }
+
+        $this->logger->info(
+            'listTools: Found ' . $total . ' tools, returning ' . count($page) . ' from offset ' . $offset,
+            ['server' => $this->serverName]
+        );
+
+        return JsonRpc::successResponse($id, $result);
+    }
+
+    private function encodeListCursor(int $offset): string
+    {
+        return base64_encode((string) json_encode(['offset' => $offset], JSON_THROW_ON_ERROR));
+    }
+
+    private function decodeListCursor(string $cursor): ?int
+    {
+        $decoded = base64_decode($cursor, true);
+
+        if ($decoded === false) {
+            return null;
+        }
+
+        try {
+            $data = json_decode($decoded, true, 2, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (!is_array($data) || !isset($data['offset']) || !is_numeric($data['offset'])) {
+            return null;
+        }
+
+        $offset = (int) $data['offset'];
+
+        return $offset >= 0 ? $offset : null;
     }
 
     private function handleCallTool(mixed $id, array $params): array

--- a/admin/src/Service/RpcService.php
+++ b/admin/src/Service/RpcService.php
@@ -295,11 +295,12 @@ class RpcService
     private function searchArticles(array $params): array
     {
         $query = [];
-        foreach (['search', 'language', 'catid', 'state', 'author', 'limit', 'offset'] as $key) {
+        foreach (['search', 'language', 'catid', 'state', 'author'] as $key) {
             if (isset($params[$key])) {
                 $query[$key] = $params[$key];
             }
         }
+        $query = array_merge($query, $this->buildPageQuery($params));
 
         $cacheKey = 'articles_search:' . md5(json_encode($query));
         return $this->withPaginationMetadata(
@@ -307,7 +308,9 @@ class RpcService
                 $response = $this->rest->get('api/index.php/v1/content/articles', $query);
                 return $this->injectRawArticleContent($response);
             }),
-            $params
+            $params,
+            'data',
+            true
         );
     }
 
@@ -434,13 +437,7 @@ class RpcService
             throw new \InvalidArgumentException('id is required');
         }
 
-        $query = [];
-        if (isset($params['limit'])) {
-            $query['page[limit]'] = (int) $params['limit'];
-        }
-        if (isset($params['offset'])) {
-            $query['page[offset]'] = (int) $params['offset'];
-        }
+        $query = $this->buildPageQuery($params);
 
         $cacheKey = 'article_versions:' . $articleId . ':' . md5(json_encode($query));
         return $this->withPaginationMetadata(
@@ -450,7 +447,9 @@ class RpcService
                     $query
                 );
             }),
-            $params
+            $params,
+            'data',
+            true
         );
     }
 
@@ -887,18 +886,19 @@ class RpcService
             : 'api/index.php/v1/menus/site/items';
 
         $query = [];
-        foreach (['menutype', 'limit', 'offset'] as $key) {
-            if (isset($params[$key])) {
-                $query[$key] = $params[$key];
-            }
+        if (isset($params['menutype'])) {
+            $query['menutype'] = $params['menutype'];
         }
+        $query = array_merge($query, $this->buildPageQuery($params));
 
         $cacheKey = 'menu_items:' . $client . ':' . md5(json_encode($query));
         return $this->withPaginationMetadata(
             $this->cache->remember($cacheKey, function () use ($path, $query) {
                 return $this->rest->get($path, $query);
             }),
-            $params
+            $params,
+            'data',
+            true
         );
     }
 
@@ -2133,12 +2133,33 @@ class RpcService
     }
 
     /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    private function buildPageQuery(array $params): array
+    {
+        $query = [];
+        if (isset($params['limit'])) {
+            $query['page[limit]'] = max(1, (int) $params['limit']);
+        }
+        if (isset($params['offset'])) {
+            $query['page[offset]'] = max(0, (int) $params['offset']);
+        }
+
+        return $query;
+    }
+
+    /**
      * @param  array<string, mixed>  $response
      * @param  array<string, mixed>  $params
      * @return array<string, mixed>
      */
-    private function withPaginationMetadata(array $response, array $params = [], string $itemsKey = 'data'): array
-    {
+    private function withPaginationMetadata(
+        array $response,
+        array $params = [],
+        string $itemsKey = 'data',
+        bool $apiHandlesPaging = false
+    ): array {
         if (!isset($response[$itemsKey]) || !is_array($response[$itemsKey])) {
             return $response;
         }
@@ -2150,8 +2171,8 @@ class RpcService
 
         $offset = max(0, (int) ($params['offset'] ?? 0));
         $limit = isset($params['limit']) ? max(1, (int) $params['limit']) : null;
-        $apiPaginated = $this->responseIsApiPaginated($response);
-        $total = $this->inferTotalCount($response, $items);
+        $apiPaginated = $this->responseIsApiPaginated($response, $params, $apiHandlesPaging);
+        $total = $this->inferTotalCount($response, $items, $params);
 
         if ($limit !== null && !$apiPaginated) {
             $response[$itemsKey] = array_values(array_slice($items, $offset, $limit));
@@ -2160,13 +2181,14 @@ class RpcService
         $count = count($response[$itemsKey]);
         $effectiveOffset = $apiPaginated ? $this->inferApiOffset($response, $offset) : $offset;
         $nextOffset = $effectiveOffset + $count;
+        $hasMore = $this->inferHasMore($response, $effectiveOffset, $count, $total, $limit);
 
         $response['pagination'] = [
             'total_count' => $total,
             'count' => $count,
             'offset' => $effectiveOffset,
-            'has_more' => $nextOffset < $total,
-            'next_offset' => $nextOffset < $total ? $nextOffset : null,
+            'has_more' => $hasMore,
+            'next_offset' => $hasMore ? $nextOffset : null,
         ];
 
         if ($limit !== null) {
@@ -2186,29 +2208,100 @@ class RpcService
 
     /**
      * @param  array<mixed>  $items
+     * @param  array<string, mixed>  $params
      */
-    private function inferTotalCount(array $response, array $items): int
+    private function inferTotalCount(array $response, array $items, array $params = []): int
     {
         $meta = $response['meta'] ?? [];
+        if (!is_array($meta)) {
+            return count($items);
+        }
+
         foreach (['total-items', 'total_items', 'total'] as $key) {
             if (isset($meta[$key]) && is_numeric($meta[$key])) {
                 return (int) $meta[$key];
             }
         }
 
-        return count($items);
+        $totalPages = (int) ($meta['total-pages'] ?? $meta['total_pages'] ?? 0);
+        if ($totalPages <= 1) {
+            return count($items);
+        }
+
+        $pageOffset = (int) ($meta['page-offset'] ?? $meta['page_offset'] ?? ($params['offset'] ?? 0));
+        $requestedLimit = isset($params['limit']) ? (int) $params['limit'] : null;
+        $pageLimit = $this->inferPageLimit($response, count($items), $pageOffset, $requestedLimit);
+        $itemCount = count($items);
+
+        if ($itemCount > 0 && $itemCount < $pageLimit) {
+            return $pageOffset + $itemCount;
+        }
+
+        return $totalPages * $pageLimit;
     }
 
     /**
      * @param  array<string, mixed>  $response
+     * @param  array<string, mixed>  $params
      */
-    private function responseIsApiPaginated(array $response): bool
+    private function responseIsApiPaginated(array $response, array $params = [], bool $apiHandlesPaging = false): bool
+    {
+        if ($apiHandlesPaging && (isset($params['limit']) || isset($params['offset']))) {
+            return true;
+        }
+
+        $meta = $response['meta'] ?? [];
+        if (!is_array($meta)) {
+            return false;
+        }
+
+        $totalPages = (int) ($meta['total-pages'] ?? $meta['total_pages'] ?? 0);
+        if ($totalPages > 1) {
+            return true;
+        }
+
+        return isset($meta['page-limit'])
+            || isset($meta['page_limit'])
+            || isset($meta['page-offset'])
+            || isset($meta['page_offset']);
+    }
+
+    private function inferPageLimit(array $response, int $count, int $offset, ?int $requestedLimit): int
     {
         $meta = $response['meta'] ?? [];
+        if (is_array($meta)) {
+            $pageLimit = (int) ($meta['page-limit'] ?? $meta['page_limit'] ?? 0);
+            if ($pageLimit > 0) {
+                return $pageLimit;
+            }
+        }
 
-        return isset($meta['total-items'], $meta['page-limit'])
-            || isset($meta['total_items'], $meta['page-limit'])
-            || isset($meta['page-offset'], $meta['page-limit']);
+        if ($requestedLimit !== null && $requestedLimit > 0) {
+            return $requestedLimit;
+        }
+
+        return max($count, 1);
+    }
+
+    private function inferHasMore(array $response, int $offset, int $count, int $total, ?int $requestedLimit): bool
+    {
+        if ($count === 0) {
+            return false;
+        }
+
+        $meta = $response['meta'] ?? [];
+        if (is_array($meta)) {
+            $totalPages = (int) ($meta['total-pages'] ?? $meta['total_pages'] ?? 0);
+            if ($totalPages > 1) {
+                $pageLimit = $this->inferPageLimit($response, $count, $offset, $requestedLimit);
+                $pageOffset = (int) ($meta['page-offset'] ?? $meta['page_offset'] ?? $offset);
+                $currentPage = (int) floor($pageOffset / max($pageLimit, 1)) + 1;
+
+                return $currentPage < $totalPages;
+            }
+        }
+
+        return ($offset + $count) < $total;
     }
 
     /**

--- a/admin/src/Service/RpcService.php
+++ b/admin/src/Service/RpcService.php
@@ -1944,9 +1944,11 @@ class RpcService
     {
         $hasContent = isset($params['content']) && $params['content'] !== '';
         $hasUrl     = isset($params['source_url']) && $params['source_url'] !== '';
+        $hasPath    = isset($params['source_path']) && $params['source_path'] !== '';
 
-        if ($hasContent && $hasUrl) {
-            throw new \InvalidArgumentException('Provide either content or source_url, not both');
+        $sources = (int) $hasContent + (int) $hasUrl + (int) $hasPath;
+        if ($sources > 1) {
+            throw new \InvalidArgumentException('Provide exactly one of content, source_url, or source_path');
         }
 
         if ($hasContent) {
@@ -1958,10 +1960,62 @@ class RpcService
         }
 
         if ($hasUrl) {
-            return $this->rest->fetchUrlContent((string) $params['source_url']);
+            return $this->rest->fetchUrlContent((string) $params['source_url'], 120.0);
         }
 
-        throw new \InvalidArgumentException('Either content or source_url is required');
+        if ($hasPath) {
+            return $this->readExtensionPackageFromPath((string) $params['source_path']);
+        }
+
+        throw new \InvalidArgumentException('One of content, source_url, or source_path is required');
+    }
+
+    private function readExtensionPackageFromPath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            throw new \InvalidArgumentException('source_path is required');
+        }
+
+        if (!is_file($path)) {
+            throw new \InvalidArgumentException('source_path does not exist or is not a file');
+        }
+
+        $real = realpath($path);
+        if ($real === false) {
+            throw new \InvalidArgumentException('source_path could not be resolved');
+        }
+
+        if (!preg_match('/\.zip$/i', $real)) {
+            throw new \InvalidArgumentException('source_path must point to a .zip file');
+        }
+
+        $allowedRoots = array_values(array_filter(array_map(
+            static fn (string $root): string => realpath($root) ?: '',
+            array_unique([
+                (string) Factory::getApplication()->get('tmp_path'),
+                JPATH_ROOT,
+            ])
+        )));
+
+        $allowed = false;
+        foreach ($allowedRoots as $root) {
+            if ($root !== '' && str_starts_with($real, $root . DIRECTORY_SEPARATOR)) {
+                $allowed = true;
+                break;
+            }
+        }
+
+        if (!$allowed) {
+            throw new \InvalidArgumentException('source_path must be under Joomla tmp_path or the site root');
+        }
+
+        $bytes = file_get_contents($real);
+        if ($bytes === false) {
+            throw new \RuntimeException('Failed to read source_path');
+        }
+
+        return $bytes;
     }
 
     private function listArticleAssociations(array $params): array

--- a/admin/src/Service/ToolRegistry.php
+++ b/admin/src/Service/ToolRegistry.php
@@ -1024,12 +1024,27 @@ class ToolRegistry
 
         $this->register([
             'name' => 'install_extension',
-            'description' => 'Install a Joomla extension from a zip package. Provide either base64 `content` or a `source_url` that the server will download. WARNING: this is arbitrary code execution — only allow trusted callers.',
+            'description' => 'Install a Joomla extension from a zip package. '
+                . 'Provide exactly one of: `source_url` (preferred — server downloads the package), '
+                . '`source_path` (absolute path to a .zip already on the Joomla server), '
+                . 'or base64 `content` (small packages only). '
+                . 'Do not read local .zip files in the MCP client and pass them as content — MCP clients cannot read large binary files. '
+                . 'WARNING: this is arbitrary code execution — only allow trusted callers.',
             'inputSchema' => [
                 'type' => 'object',
                 'properties' => [
-                    'content' => ['type' => 'string', 'description' => 'Base64-encoded contents of the .zip package'],
-                    'source_url' => ['type' => 'string', 'description' => 'URL the server will download (server fetches bytes itself; no client redirect)'],
+                    'content' => [
+                        'type' => 'string',
+                        'description' => 'Base64-encoded contents of the .zip package (small packages only; prefer source_url or source_path)',
+                    ],
+                    'source_url' => [
+                        'type' => 'string',
+                        'description' => 'URL the server will download (preferred for release packages and GitHub assets)',
+                    ],
+                    'source_path' => [
+                        'type' => 'string',
+                        'description' => 'Absolute path on the Joomla server to an existing .zip file (must be under tmp_path or the site root)',
+                    ],
                 ],
             ],
             'annotations' => [

--- a/evaluations/joomla-mcp-eval.xml
+++ b/evaluations/joomla-mcp-eval.xml
@@ -40,4 +40,24 @@
       <question>For article ID 1, how many associated items are returned by list_article_associations? Return only the integer.</question>
       <answer>0</answer>
    </qa_pair>
+   <qa_pair>
+      <question>Call search_articles with no limit or offset. Does pagination.has_more equal (meta.total-pages &gt; 1)? Answer True or False only.</question>
+      <answer>True</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Using list_menu_items with client set to site and no limit or offset, does pagination.has_more equal (meta.total-pages &gt; 1)? Answer True or False only.</question>
+      <answer>True</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Call search_articles with limit 5 and offset 20. If meta.total-pages on a no-limit search_articles call is greater than 1, is pagination.count greater than 0? Answer True or False only.</question>
+      <answer>True</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Call search_articles twice with limit 5: once at offset 0 and once at offset 20. Do the two result sets share any article ID? Answer True or False only.</question>
+      <answer>False</answer>
+   </qa_pair>
+   <qa_pair>
+      <question>Page through all search_articles results using limit 5 and pagination.next_offset until has_more is false. If the first no-limit search_articles call has meta.total-pages greater than 1, is the unique article count greater than the first page item count? Answer True or False only.</question>
+      <answer>True</answer>
+   </qa_pair>
 </evaluation>

--- a/mcpserver.xml
+++ b/mcpserver.xml
@@ -6,7 +6,7 @@
     <authorEmail>allan@onepointltd.com</authorEmail>
     <copyright>Copyright (C) 2026 Onepoint Consulting Ltd</copyright>
     <creationDate>2025-08-13</creationDate>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <license>GPL-2.0-or-later</license>
     <description>Model Context Protocol server component for Joomla</description>
     <element>com_mcpserver</element>

--- a/mcpserver.xml
+++ b/mcpserver.xml
@@ -6,7 +6,7 @@
     <authorEmail>allan@onepointltd.com</authorEmail>
     <copyright>Copyright (C) 2026 Onepoint Consulting Ltd</copyright>
     <creationDate>2025-08-13</creationDate>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <license>GPL-2.0-or-later</license>
     <description>Model Context Protocol server component for Joomla</description>
     <element>com_mcpserver</element>

--- a/scripts/joomla_mcp_client.py
+++ b/scripts/joomla_mcp_client.py
@@ -75,8 +75,27 @@ class JoomlaHttpClient:
         return self.call("initialize", {"protocolVersion": "2025-06-18", "capabilities": {}})
 
     def list_tools(self) -> list[dict[str, Any]]:
-        result = self.call("tools/list", {})
-        return result.get("tools", []) if isinstance(result, dict) else []
+        tools: list[dict[str, Any]] = []
+        cursor: str | None = None
+
+        while True:
+            params: dict[str, Any] = {}
+            if cursor is not None:
+                params["cursor"] = cursor
+
+            result = self.call("tools/list", params)
+            if not isinstance(result, dict):
+                break
+
+            page = result.get("tools", [])
+            if isinstance(page, list):
+                tools.extend(page)
+
+            cursor = result.get("nextCursor")
+            if not cursor:
+                break
+
+        return tools
 
     def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> Any:
         result = self.call("tools/call", {"name": name, "arguments": arguments or {}})

--- a/scripts/pagination_eval.py
+++ b/scripts/pagination_eval.py
@@ -1,0 +1,107 @@
+"""Pagination checks for the Joomla MCP evaluation suite."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from joomla_mcp_client import JoomlaHttpClient
+
+
+def _article_ids(result: dict[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for row in result.get("data", []):
+        if not isinstance(row, dict):
+            continue
+        attrs = row.get("attributes", row)
+        if isinstance(attrs, dict) and attrs.get("id") is not None:
+            ids.append(str(attrs["id"]))
+        elif row.get("id") is not None:
+            ids.append(str(row["id"]))
+    return ids
+
+
+def _meta_total_pages(result: dict[str, Any]) -> int:
+    meta = result.get("meta") or {}
+    if not isinstance(meta, dict):
+        return 1
+    value = meta.get("total-pages", meta.get("total_pages", 1))
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return 1
+
+
+def pagination_has_more_matches_meta(client: JoomlaHttpClient, tool: str, arguments: dict[str, Any]) -> str:
+    result = client.call_tool(tool, arguments)
+    if not isinstance(result, dict):
+        return "False"
+    pagination = result.get("pagination") or {}
+    has_more = bool(pagination.get("has_more"))
+    return "True" if has_more == (_meta_total_pages(result) > 1) else "False"
+
+
+def expected_pagination_has_more_matches_meta() -> str:
+    return "True"
+
+
+def articles_page_two_has_items(client: JoomlaHttpClient, limit: int, offset: int) -> str:
+    first = client.call_tool("search_articles", {})
+    if not isinstance(first, dict) or _meta_total_pages(first) <= 1:
+        return "False"
+    result = client.call_tool("search_articles", {"limit": limit, "offset": offset})
+    if not isinstance(result, dict):
+        return "False"
+    count = int((result.get("pagination") or {}).get("count", 0))
+    return "True" if count > 0 else "False"
+
+
+def expected_articles_page_two_has_items(client: JoomlaHttpClient) -> str:
+    first = client.call_tool("search_articles", {})
+    if not isinstance(first, dict):
+        return "False"
+    return "True" if _meta_total_pages(first) > 1 else "False"
+
+
+def search_articles_page_overlap(client: JoomlaHttpClient, limit: int, first_offset: int, second_offset: int) -> str:
+    first = client.call_tool("search_articles", {"limit": limit, "offset": first_offset})
+    second = client.call_tool("search_articles", {"limit": limit, "offset": second_offset})
+    first_ids = set(_article_ids(first if isinstance(first, dict) else {}))
+    second_ids = set(_article_ids(second if isinstance(second, dict) else {}))
+    overlap = bool(first_ids & second_ids)
+    return "True" if overlap else "False"
+
+
+def expected_search_articles_page_overlap(client: JoomlaHttpClient) -> str:
+    first = client.call_tool("search_articles", {})
+    if not isinstance(first, dict):
+        return "False"
+    return "False" if _meta_total_pages(first) > 1 else "False"
+
+
+def walk_exceeds_first_api_page(client: JoomlaHttpClient, limit: int) -> str:
+    first = client.call_tool("search_articles", {})
+    if not isinstance(first, dict) or _meta_total_pages(first) <= 1:
+        return "False"
+    offset = 0
+    seen: set[str] = set()
+    for _ in range(100):
+        result = client.call_tool("search_articles", {"limit": limit, "offset": offset})
+        if not isinstance(result, dict):
+            break
+        seen.update(_article_ids(result))
+        pagination = result.get("pagination") or {}
+        if not pagination.get("has_more"):
+            break
+        next_offset = pagination.get("next_offset")
+        if next_offset is None:
+            break
+        offset = int(next_offset)
+    first_page_size = len(_article_ids(first))
+    return "True" if len(seen) > first_page_size else "False"
+
+
+def expected_walk_exceeds_first_api_page(client: JoomlaHttpClient) -> str:
+    first = client.call_tool("search_articles", {})
+    if not isinstance(first, dict):
+        return "False"
+    return "True" if _meta_total_pages(first) > 1 else "False"

--- a/scripts/resolve_eval_answers.py
+++ b/scripts/resolve_eval_answers.py
@@ -13,6 +13,16 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from joomla_mcp_client import JoomlaHttpClient, JoomlaMcpError
+from pagination_eval import (
+    articles_page_two_has_items,
+    expected_articles_page_two_has_items,
+    expected_pagination_has_more_matches_meta,
+    expected_search_articles_page_overlap,
+    expected_walk_exceeds_first_api_page,
+    pagination_has_more_matches_meta,
+    search_articles_page_overlap,
+    walk_exceeds_first_api_page,
+)
 
 
 def _enabled_templates(client: JoomlaHttpClient, site_client: str) -> list[dict]:
@@ -60,7 +70,7 @@ def _cassiopeia_style_count(client: JoomlaHttpClient) -> int:
     return count
 
 
-def build_qa_pairs(client: JoomlaHttpClient) -> list[dict[str, str]]:
+def build_qa_pairs(client: JoomlaHttpClient, *, for_verification: bool = False) -> list[dict[str, str]]:
     tools = client.list_tools()
     read_only_count = sum(
         1 for tool in tools if (tool.get("annotations") or {}).get("readOnlyHint") is True
@@ -154,6 +164,64 @@ def build_qa_pairs(client: JoomlaHttpClient) -> list[dict[str, str]]:
                 "Return only the integer."
             ),
             "answer": str(association_count),
+        },
+        {
+            "question": (
+                "Call search_articles with no limit or offset. Does pagination.has_more equal "
+                "(meta.total-pages > 1)? Answer True or False only."
+            ),
+            "answer": (
+                pagination_has_more_matches_meta(client, "search_articles", {})
+                if for_verification
+                else expected_pagination_has_more_matches_meta()
+            ),
+        },
+        {
+            "question": (
+                "Using list_menu_items with client set to site and no limit or offset, does pagination.has_more "
+                "equal (meta.total-pages > 1)? Answer True or False only."
+            ),
+            "answer": (
+                pagination_has_more_matches_meta(client, "list_menu_items", {"client": "site"})
+                if for_verification
+                else expected_pagination_has_more_matches_meta()
+            ),
+        },
+        {
+            "question": (
+                "Call search_articles with limit 5 and offset 20. If meta.total-pages on a no-limit "
+                "search_articles call is greater than 1, is pagination.count greater than 0? "
+                "Answer True or False only."
+            ),
+            "answer": (
+                articles_page_two_has_items(client, 5, 20)
+                if for_verification
+                else expected_articles_page_two_has_items(client)
+            ),
+        },
+        {
+            "question": (
+                "Call search_articles twice with limit 5: once at offset 0 and once at offset 20. "
+                "Do the two result sets share any article ID? Answer True or False only."
+            ),
+            "answer": (
+                search_articles_page_overlap(client, 5, 0, 20)
+                if for_verification
+                else expected_search_articles_page_overlap(client)
+            ),
+        },
+        {
+            "question": (
+                "Page through all search_articles results using limit 5 and pagination.next_offset until "
+                "has_more is false. If the first no-limit search_articles call has meta.total-pages greater "
+                "than 1, is the unique article count greater than the first page item count? "
+                "Answer True or False only."
+            ),
+            "answer": (
+                walk_exceeds_first_api_page(client, 5)
+                if for_verification
+                else expected_walk_exceeds_first_api_page(client)
+            ),
         },
     ]
 

--- a/scripts/run_eval_local.py
+++ b/scripts/run_eval_local.py
@@ -36,7 +36,7 @@ def main() -> int:
     client = JoomlaHttpClient(args.url, args.token)
     try:
         client.initialize()
-        actual_pairs = build_qa_pairs(client)
+        actual_pairs = build_qa_pairs(client, for_verification=True)
     except JoomlaMcpError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1

--- a/update.xml
+++ b/update.xml
@@ -6,6 +6,22 @@
         <element>com_mcpserver</element>
         <type>component</type>
         <client>administrator</client>
+        <version>1.3.2</version>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.3.2/com_mcpserver-1.3.2.zip</downloadurl>
+        </downloads>
+        <sha256>868c6c18913f10bdb4aedf62329e45653eab1e170cabd0925efa131eed0597e4</sha256>
+        <targetplatform name="joomla" version="((4\.)|(5\.)|(6\.))" />
+        <php_minimum>8.1</php_minimum>
+        <maintainer>Onepoint Consulting Ltd</maintainer>
+        <maintainerurl>https://github.com/OnepointConsultingLtd/joomla-mcp-server</maintainerurl>
+    </update>
+    <update>
+        <name>MCP Server for Joomla</name>
+        <description>Model Context Protocol server component for Joomla</description>
+        <element>com_mcpserver</element>
+        <type>component</type>
+        <client>administrator</client>
         <version>1.3.1</version>
         <downloads>
             <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.3.1/com_mcpserver-1.3.1.zip</downloadurl>

--- a/update.xml
+++ b/update.xml
@@ -6,6 +6,22 @@
         <element>com_mcpserver</element>
         <type>component</type>
         <client>administrator</client>
+        <version>1.3.3</version>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.3.3/com_mcpserver-1.3.3.zip</downloadurl>
+        </downloads>
+        <sha256>5a21630773e67aa255b809259180869ff8774c063e02b76aa6e1ec54bc7939d5</sha256>
+        <targetplatform name="joomla" version="((4\.)|(5\.)|(6\.))" />
+        <php_minimum>8.1</php_minimum>
+        <maintainer>Onepoint Consulting Ltd</maintainer>
+        <maintainerurl>https://github.com/OnepointConsultingLtd/joomla-mcp-server</maintainerurl>
+    </update>
+    <update>
+        <name>MCP Server for Joomla</name>
+        <description>Model Context Protocol server component for Joomla</description>
+        <element>com_mcpserver</element>
+        <type>component</type>
+        <client>administrator</client>
         <version>1.3.2</version>
         <downloads>
             <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.3.2/com_mcpserver-1.3.2.zip</downloadurl>


### PR DESCRIPTION
## Summary

- **Fixed `tools/list` pagination** — implementing a MCP cursor-based paging (30 tools per page, `nextCursor`).
- **Improved `install_extension`** — adds `source_path` for server-side `.zip` files, prefers `source_url` over base64 `content` in the tool description.
- **Update evaluation client** — `scripts/joomla_mcp_client.py` now follows `nextCursor` when listing tools.