### PR TITLE
Release v1.3.4:  JoomlaCache session cleanup and update feed improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable release changes for MCP Server for Joomla are recorded here.
 
+## 1.3.4 - 2026-06-30
+
+- Fixed update feed infourl entries pointing to the wrong release tag.
+- Added garbage collection and session cleanup to JoomlaCache to prevent stale SSE session data accumulating.
+- Enhanced update.xml entries with maintainer, PHP minimum, and platform metadata.
+- Updated documentation.
+
 ## 1.3.3 - 2026-06-29
 
 - Fixed tools listing pagination.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@ A Joomla 4, 5 and 6 component that exposes a [Model Context Protocol (MCP)](http
 
 ## Features
 
-- HTTP JSON-RPC 2.0 MCP endpoint in both site and administrator contexts
-- Bearer token authentication with optional IP allow-listing and CORS origin control
+- Administrator dashboard with request summary (totals, error rate and auth failures), a requests-per-day chart, top tools and methods, and a requests log
+- Security with bearer token authentication, optional IP allow-listing and CORS origin control
 - Configurable fixed-window rate limiting
 - Response caching through Joomla's cache layer
 - JSON Schema validation for MCP tool inputs
 - Health endpoint for monitoring
-- Node.js stdio-to-HTTP bridge for desktop MCP clients
 - Joomla update server metadata for official releases
 
 ## MCP Tools

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Joomla 4, 5 and 6 component that exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server over HTTP JSON-RPC. It lets MCP clients such as Claude Desktop and Cursor work with Joomla content through the site's own Joomla Web Services API.
 
-**Version:** 1.3.3 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
+**Version:** 1.3.4 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
 
 ## Features
 

--- a/admin/src/Controller/RpcHandlerTrait.php
+++ b/admin/src/Controller/RpcHandlerTrait.php
@@ -74,6 +74,13 @@ trait RpcHandlerTrait
         flush();
 
         $cache = new JoomlaCache('mcp_sse');
+
+        // Deterministically reclaim orphaned SSE responses left by sessions whose
+        // consumer disconnected before reading. Safe here because this instance keeps
+        // its default lifetime (we never call set()/setLifeTime() on it) — gc() only
+        // removes entries already past the global cachetime.
+        $cache->gc();
+
         $startTime = time();
         $lastPingTime = $startTime;
         $timeout = 3600;
@@ -107,6 +114,10 @@ trait RpcHandlerTrait
 
             usleep(200000);
         }
+
+        // Drop this session's own entry in case a response was written into the gap
+        // between the final poll and loop exit, so it is not left for gc to reclaim.
+        $cache->delete($sessionId);
 
         $app->close();
     }

--- a/admin/src/Service/JoomlaCache.php
+++ b/admin/src/Service/JoomlaCache.php
@@ -40,7 +40,13 @@ class JoomlaCache implements CacheInterface
                 ? (int) ((new \DateTimeImmutable('now'))->add($ttl)->getTimestamp() - time())
                 : $ttl;
             if ($seconds > 0) {
-                $this->cache->setLifeTime($seconds);
+                // PSR-16 expresses TTL in seconds, but Joomla's setLifeTime() expects
+                // minutes (CacheStorage multiplies the value by 60). Convert so callers'
+                // second-based TTLs are honoured instead of being applied 60x too long.
+                // Round up, with a 1-minute floor (Joomla's file storage cannot express
+                // sub-minute expiry; TTL-honouring backends get ~the requested window).
+                $minutes = (int) max(1, (int) ceil($seconds / 60));
+                $this->cache->setLifeTime($minutes);
             }
         }
 
@@ -85,6 +91,19 @@ class JoomlaCache implements CacheInterface
     public function has(string $key): bool
     {
         return $this->get($key) !== null;
+    }
+
+    /**
+     * Garbage-collect expired entries across the cache store.
+     *
+     * Uses the instance's default lifetime (the global Joomla cachetime). Do NOT
+     * call this after set()/setLifeTime() on the same instance: Joomla's file
+     * storage gc() recurses the entire cache base and would purge other groups'
+     * entries using whatever (possibly shortened) lifetime is in effect.
+     */
+    public function gc(): bool
+    {
+        return (bool) $this->cache->gc();
     }
 
     public function deleteByPrefix(string $prefix): void

--- a/changelog.xml
+++ b/changelog.xml
@@ -3,6 +3,21 @@
     <changelog>
         <element>com_mcpserver</element>
         <type>component</type>
+        <version>1.3.4</version>
+        <fix>
+            <item>Fixed update feed infourl entries pointing to the wrong release tag.</item>
+        </fix>
+        <addition>
+            <item>Added garbage collection and session cleanup to JoomlaCache to prevent stale SSE session data accumulating.</item>
+        </addition>
+        <change>
+            <item>Enhanced update.xml entries with maintainer, PHP minimum, and platform metadata.</item>
+            <item>Updated documentation.</item>
+        </change>
+    </changelog>
+    <changelog>
+        <element>com_mcpserver</element>
+        <type>component</type>
         <version>1.3.3</version>
         <fix>
             <item>Fixed tools listing pagination.</item>

--- a/mcpserver.xml
+++ b/mcpserver.xml
@@ -6,7 +6,7 @@
     <authorEmail>allan@onepointltd.com</authorEmail>
     <copyright>Copyright (C) 2026 Onepoint Consulting Ltd</copyright>
     <creationDate>2025-08-13</creationDate>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <license>GPL-2.0-or-later</license>
     <description>Model Context Protocol server component for Joomla</description>
     <element>com_mcpserver</element>

--- a/update.xml
+++ b/update.xml
@@ -6,6 +6,26 @@
         <element>com_mcpserver</element>
         <type>component</type>
         <client>administrator</client>
+        <version>1.3.4</version>
+        <infourl title="MCP Server for Joomla 1.3.4">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/tag/v1.3.4</infourl>
+        <downloads>
+            <downloadurl type="full" format="zip">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/download/v1.3.4/com_mcpserver-1.3.4.zip</downloadurl>
+        </downloads>
+        <tags>
+            <tag>stable</tag>
+        </tags>
+        <sha256>7c6313bf159db62ccc6fe010065178dcdc841c8a5fe66da140b85942b7cfe5cb</sha256>
+        <targetplatform name="joomla" version="((4\.)|(5\.)|(6\.))" />
+        <php_minimum>8.1</php_minimum>
+        <maintainer>Onepoint Consulting Ltd</maintainer>
+        <maintainerurl>https://www.onepointltd.com</maintainerurl>
+    </update>
+    <update>
+        <name>MCP Server for Joomla</name>
+        <description>Model Context Protocol server component for Joomla</description>
+        <element>com_mcpserver</element>
+        <type>component</type>
+        <client>administrator</client>
         <version>1.3.3</version>
         <infourl title="MCP Server for Joomla 1.3.3">https://github.com/OnepointConsultingLtd/joomla-mcp-server/releases/tag/v1.3.3</infourl>
         <downloads>


### PR DESCRIPTION
## Summary

- Adds garbage collection and session cleanup to `JoomlaCache` to prevent accumulation of stale cache data.
- Updated documentation.
