### PR TITLE
Release v1.7.1: create template files in existing folders and add a backup warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable release changes for MCP Server for Joomla are recorded here.
 
+## 1.7.1 - 2026-09-07
+
+- `update_template_file` now creates a file when it does not exist, provided its parent directory already does (for example a second layout in an existing override folder). The response reports `created`.
+- A missing parent directory is now reported as "Directory does not exist" rather than implying a path-traversal attempt.
+- Added a backup warning on the component landing page, reminding administrators to take a full backup and test with Read-Only Mode before connecting a write-capable LLM client.
+
 ## 1.7.0 - 2026-08-13
 
 - Added four read-only site-diagnostics tools (`get_rendered_page`, `diff_article_versions`, `seo_audit_articles`, `check_internal_links`) so an agent can verify what a visitor sees, what changed between article versions, and whether content has SEO or internal-link problems.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Joomla 4, 5 and 6 component that exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server over HTTP JSON-RPC. It lets MCP clients such as Claude Desktop and Cursor work with Joomla content through the site's own Joomla Web Services API.
 
-**Version:** 1.7.0 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
+**Version:** 1.7.1 · **Requires:** Joomla 4, 5 or 6 · PHP 8.1+ · **Licence:** GPL-2.0-or-later
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Article versioning tools require Joomla article versioning to be enabled.
 |---|---|
 | `list_template_files` | List editable source files of an installed template (Joomla's "Customise" view) |
 | `get_template_file` | Read the source of a single template file |
-| `update_template_file` | Overwrite the source of an existing template file |
+| `update_template_file` | Write the source of a template file, creating it if its parent directory exists |
 | `create_template_override` | Create a template override by copying a core view, module, plugin or layout into the template |
 
 ### Extensions

--- a/admin/language/en-GB/en-GB.com_mcpserver.ini
+++ b/admin/language/en-GB/en-GB.com_mcpserver.ini
@@ -47,6 +47,8 @@ COM_MCPSERVER_CONFIG_METRICS_RETENTION_DAYS="Metrics Retention (days)"
 COM_MCPSERVER_CONFIG_METRICS_RETENTION_DAYS_DESC="Request log rows older than this are automatically pruned. Default 30."
 
 COM_MCPSERVER_COMPONENT_INTRO="Welcome to MCP Server for Joomla. Use the Options button to configure the component."
+COM_MCPSERVER_BACKUP_WARNING_LABEL="Back up your site before connecting an LLM"
+COM_MCPSERVER_BACKUP_WARNING_DESC="Any AI client connected to this server can create, change and delete real data on this site - articles, categories, menus, modules, users and extensions. LLMs make mistakes and can misread an instruction, and there is no undo for most of these operations. Take a full file and database backup before you connect a client, and test with Read-Only Mode enabled (Options, Security Settings) before you allow write access."
 COM_MCPSERVER_MCPB_DOWNLOAD="Download Claude Desktop extension"
 COM_MCPSERVER_MCPB_ERROR="The Claude Desktop extension bundle could not be generated on this server (%s). Please download it from the GitHub release page instead."
 

--- a/admin/src/Service/RpcService.php
+++ b/admin/src/Service/RpcService.php
@@ -2413,10 +2413,14 @@ class RpcService
             throw new \InvalidArgumentException('path and source are required');
         }
 
-        $path = $this->safeTemplatePath($this->templateBasePath($template, $media), $relative);
+        // safeTemplatePath() has already established that the parent directory
+        // exists and sits inside the template, so a missing file here is a new
+        // one to create — e.g. a second layout in an existing override folder.
+        $path   = $this->safeTemplatePath($this->templateBasePath($template, $media), $relative);
+        $isNew  = !file_exists($path);
 
-        if (!is_file($path)) {
-            throw new \InvalidArgumentException('File not found (create an override first): ' . $relative);
+        if (!$isNew && !is_file($path)) {
+            throw new \InvalidArgumentException('Path is not a file: ' . $relative);
         }
 
         if (!$this->templateExtensionAllowed($path)) {
@@ -2430,7 +2434,9 @@ class RpcService
             throw new \InvalidArgumentException('joomla.asset.json must contain valid JSON');
         }
 
-        if (!is_writable($path) || file_put_contents($path, $source) === false) {
+        $writable = $isNew ? is_writable(\dirname($path)) : is_writable($path);
+
+        if (!$writable || file_put_contents($path, $source) === false) {
             throw new \RuntimeException('Failed to write file (check permissions): ' . $relative);
         }
 
@@ -2438,6 +2444,7 @@ class RpcService
             'extension_id'  => $template->extension_id,
             'template'      => $template->element,
             'path'          => $relative,
+            'created'       => $isNew,
             'bytes_written' => strlen($source),
         ];
     }
@@ -2544,7 +2551,15 @@ class RpcService
         $realBase = realpath($base) ?: $base;
         $parent   = realpath(\dirname($path));
 
-        if ($parent === false || ($parent !== $realBase && !str_starts_with($parent, $realBase . '/'))) {
+        // '..' is rejected above, so an unresolvable parent means the directory
+        // is simply absent — say so rather than implying a traversal attempt.
+        if ($parent === false) {
+            throw new \InvalidArgumentException(
+                'Directory does not exist: ' . trim(\dirname('/' . ltrim($relative, '/')), '/')
+            );
+        }
+
+        if ($parent !== $realBase && !str_starts_with($parent, $realBase . '/')) {
             throw new \InvalidArgumentException('Path is outside the template directory');
         }
 

--- a/admin/src/Service/ToolRegistry.php
+++ b/admin/src/Service/ToolRegistry.php
@@ -1160,8 +1160,9 @@ class ToolRegistry
 
         $this->register([
             'name' => 'update_template_file',
-            'description' => 'Overwrite the source of an existing template file (Joomla\'s template "Customise" editor). The file must already '
-                . 'exist; create overrides with create_template_override first. Line endings are normalised to Unix, and joomla.asset.json '
+            'description' => 'Write the source of a template file (Joomla\'s template "Customise" editor). Overwrites the file if it exists, '
+                . 'otherwise creates it, provided its parent directory already exists — use create_template_override to add a new override '
+                . 'folder first. The response reports `created`. Line endings are normalised to Unix, and joomla.asset.json '
                 . 'must remain valid JSON. `path` is relative to the template root. '
                 . 'WARNING: this can write executable PHP into the site — arbitrary code execution; only allow trusted callers.',
             'inputSchema' => [

--- a/admin/tmpl/mcpcomponent/default.php
+++ b/admin/tmpl/mcpcomponent/default.php
@@ -36,7 +36,15 @@ HTMLHelper::_('behavior.core');
             </a>
         </div>
     </div>
-    
+
+    <div class="alert alert-warning d-flex" role="alert">
+        <span class="icon-warning icon-fw me-2 mt-1" aria-hidden="true"></span>
+        <div>
+            <h2 class="alert-heading h5"><?php echo Text::_('COM_MCPSERVER_BACKUP_WARNING_LABEL'); ?></h2>
+            <p class="mb-0"><?php echo Text::_('COM_MCPSERVER_BACKUP_WARNING_DESC'); ?></p>
+        </div>
+    </div>
+
     <div class="card mb-4 shadow-sm">
         <div class="card-header d-flex justify-content-between align-items-center">
             <h5 class="mb-0">MCP Client Configuration</h5>

--- a/changelog.xml
+++ b/changelog.xml
@@ -3,6 +3,18 @@
     <changelog>
         <element>com_mcpserver</element>
         <type>component</type>
+        <version>1.7.1</version>
+        <addition>
+            <item>Added a backup warning on the component landing page, reminding administrators to take a full backup and test with Read-Only Mode before connecting a write-capable LLM client.</item>
+        </addition>
+        <change>
+            <item>update_template_file now creates a file when it does not exist, provided its parent directory already does (for example a second layout in an existing override folder). The response reports created.</item>
+            <item>A missing parent directory is now reported as "Directory does not exist" rather than implying a path-traversal attempt.</item>
+        </change>
+    </changelog>
+    <changelog>
+        <element>com_mcpserver</element>
+        <type>component</type>
         <version>1.7.0</version>
         <addition>
             <item>Added four read-only site-diagnostics tools (get_rendered_page, diff_article_versions, seo_audit_articles, check_internal_links) so an agent can verify what a visitor sees, what changed between article versions, and whether content has SEO or internal-link problems.</item>

--- a/mcpserver.xml
+++ b/mcpserver.xml
@@ -6,7 +6,7 @@
     <authorEmail>allan@onepointltd.com</authorEmail>
     <copyright>Copyright (C) 2026 Onepoint Consulting Ltd</copyright>
     <creationDate>2025-08-13</creationDate>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <license>GPL-2.0-or-later</license>
     <description>Model Context Protocol server component for Joomla</description>
     <element>com_mcpserver</element>

--- a/tests/Stubs/joomla.php
+++ b/tests/Stubs/joomla.php
@@ -13,6 +13,8 @@ namespace Joomla\CMS {
     {
         public static ?object $application = null;
 
+        public static ?object $database = null;
+
         public static function getApplication(): object
         {
             if (self::$application === null) {
@@ -22,9 +24,39 @@ namespace Joomla\CMS {
             return self::$application;
         }
 
+        public static function getDbo(): object
+        {
+            if (self::$database === null) {
+                throw new \RuntimeException('Test database has not been installed');
+            }
+
+            return self::$database;
+        }
+
         public static function reset(): void
         {
             self::$application = null;
+            self::$database = null;
+        }
+    }
+}
+
+namespace Joomla\CMS\Component {
+    use Joomla\Registry\Registry;
+
+    class ComponentHelper
+    {
+        /** @var array<string, Registry> */
+        public static array $params = [];
+
+        public static function getParams(string $option): Registry
+        {
+            return self::$params[$option] ?? new Registry();
+        }
+
+        public static function reset(): void
+        {
+            self::$params = [];
         }
     }
 }
@@ -107,6 +139,82 @@ namespace Joomla\CMS\Uri {
         public static function root(bool $pathonly = false): string
         {
             return self::$root;
+        }
+    }
+}
+
+namespace Joomla\Component\Mcpserver\Tests\Stubs {
+    /**
+     * Query builder stand-in: records the clauses the service assembles so a
+     * test can assert on them, without parsing SQL.
+     */
+    class StubQuery
+    {
+        /** @var list<string> */
+        public array $clauses = [];
+
+        public function select(string|array $columns): self
+        {
+            $this->clauses[] = 'select ' . implode(',', (array) $columns);
+
+            return $this;
+        }
+
+        public function from(string $table): self
+        {
+            $this->clauses[] = 'from ' . $table;
+
+            return $this;
+        }
+
+        public function where(string $condition): self
+        {
+            $this->clauses[] = 'where ' . $condition;
+
+            return $this;
+        }
+    }
+
+    /**
+     * Minimal stand-in for Joomla's DatabaseDriver. Tests queue the rows that
+     * loadObject() should hand back, in call order.
+     */
+    class StubDatabase
+    {
+        /** @var list<object|null> */
+        public array $objects = [];
+
+        public ?StubQuery $lastQuery = null;
+
+        public function getQuery(bool $new = false): StubQuery
+        {
+            return new StubQuery();
+        }
+
+        public function quoteName(string|array $name): string|array
+        {
+            if (\is_array($name)) {
+                return array_map(fn(string $one): string => $this->quoteName($one), $name);
+            }
+
+            return '`' . $name . '`';
+        }
+
+        public function quote(string $text): string
+        {
+            return "'" . $text . "'";
+        }
+
+        public function setQuery(StubQuery $query): self
+        {
+            $this->lastQuery = $query;
+
+            return $this;
+        }
+
+        public function loadObject(): ?object
+        {
+            return array_shift($this->objects);
         }
     }
 }

--- a/tests/Unit/RpcServiceTemplateFilesTest.php
+++ b/tests/Unit/RpcServiceTemplateFilesTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * @package     MCP Server for Joomla
+ * @copyright   Copyright (C) 2026 Onepoint Consulting Ltd
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Joomla\Component\Mcpserver\Tests\Unit;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\Component\Mcpserver\Administrator\Service\CacheService;
+use Joomla\Component\Mcpserver\Administrator\Service\PolicyService;
+use Joomla\Component\Mcpserver\Administrator\Service\PromptRegistry;
+use Joomla\Component\Mcpserver\Administrator\Service\RestClient;
+use Joomla\Component\Mcpserver\Administrator\Service\RpcService;
+use Joomla\Component\Mcpserver\Administrator\Service\SchemaValidator;
+use Joomla\Component\Mcpserver\Administrator\Service\SimpleArrayCache;
+use Joomla\Component\Mcpserver\Administrator\Service\ToolRegistry;
+use Joomla\Component\Mcpserver\Tests\Stubs\StubDatabase;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class RpcServiceTemplateFilesTest extends TestCase
+{
+    private const EXTENSION_ID = 506;
+
+    private string $templateRoot;
+
+    protected function setUp(): void
+    {
+        $this->templateRoot = JPATH_ROOT . '/templates/cassiopeia';
+
+        // A template with one existing override directory, as create_template_override leaves it.
+        $this->makeDir($this->templateRoot . '/html/com_content/article');
+        file_put_contents($this->templateRoot . '/html/com_content/article/default.php', "<?php // original\n");
+        file_put_contents($this->templateRoot . '/index.php', "<?php // index\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeTree(JPATH_ROOT);
+        Factory::reset();
+    }
+
+    public function testUpdateTemplateFileCreatesANewFileInAnExistingOverrideDirectory(): void
+    {
+        $result = $this->toolResult($this->callTool('update_template_file', [
+            'extension_id' => self::EXTENSION_ID,
+            'path' => 'html/com_content/article/default_custom.php',
+            'source' => "<?php // new override\n",
+        ]));
+
+        $this->assertTrue($result['created']);
+        $this->assertSame('html/com_content/article/default_custom.php', $result['path']);
+        $this->assertFileExists($this->templateRoot . '/html/com_content/article/default_custom.php');
+        $this->assertSame(
+            "<?php // new override\n",
+            file_get_contents($this->templateRoot . '/html/com_content/article/default_custom.php')
+        );
+    }
+
+    public function testUpdateTemplateFileStillOverwritesAnExistingFile(): void
+    {
+        $result = $this->toolResult($this->callTool('update_template_file', [
+            'extension_id' => self::EXTENSION_ID,
+            'path' => 'html/com_content/article/default.php',
+            'source' => "<?php // replaced\r\n",
+        ]));
+
+        $this->assertFalse($result['created']);
+        // Line endings are still normalised to Unix.
+        $this->assertSame(
+            "<?php // replaced\n",
+            file_get_contents($this->templateRoot . '/html/com_content/article/default.php')
+        );
+    }
+
+    public function testUpdateTemplateFileRefusesToCreateAFileInAMissingDirectory(): void
+    {
+        $this->assertToolError(
+            $this->callTool('update_template_file', [
+                'extension_id' => self::EXTENSION_ID,
+                'path' => 'html/com_contact/contact/default.php',
+                'source' => "<?php\n",
+            ]),
+            'Directory does not exist'
+        );
+
+        $this->assertDirectoryDoesNotExist($this->templateRoot . '/html/com_contact');
+    }
+
+    public function testUpdateTemplateFileAppliesTheExtensionAllowlistToNewFiles(): void
+    {
+        $this->assertToolError(
+            $this->callTool('update_template_file', [
+                'extension_id' => self::EXTENSION_ID,
+                'path' => 'html/com_content/article/shell.phtml',
+                'source' => "<?php\n",
+            ]),
+            'File type is not editable'
+        );
+
+        $this->assertFileDoesNotExist($this->templateRoot . '/html/com_content/article/shell.phtml');
+    }
+
+    public function testUpdateTemplateFileRefusesToCreateOutsideTheTemplateRoot(): void
+    {
+        $this->assertToolError(
+            $this->callTool('update_template_file', [
+                'extension_id' => self::EXTENSION_ID,
+                'path' => '../../configuration.php',
+                'source' => "<?php\n",
+            ]),
+            'Invalid path'
+        );
+
+        $this->assertFileDoesNotExist(JPATH_ROOT . '/configuration.php');
+    }
+
+    public function testUpdateTemplateFileValidatesANewAssetManifest(): void
+    {
+        $this->assertToolError(
+            $this->callTool('update_template_file', [
+                'extension_id' => self::EXTENSION_ID,
+                'path' => 'joomla.asset.json',
+                'source' => 'not json',
+            ]),
+            'joomla.asset.json must contain valid JSON'
+        );
+
+        $this->assertFileDoesNotExist($this->templateRoot . '/joomla.asset.json');
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array<string, mixed>
+     */
+    private function callTool(string $name, array $arguments): array
+    {
+        $db = new StubDatabase();
+        $db->objects[] = (object) [
+            'extension_id' => self::EXTENSION_ID,
+            'element' => 'cassiopeia',
+            'client_id' => 0,
+        ];
+        Factory::$database = $db;
+
+        return $this->makeService()->handle([
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => $name,
+                'arguments' => $arguments,
+            ],
+        ]);
+    }
+
+    private function makeService(): RpcService
+    {
+        $policy = $this->createMock(PolicyService::class);
+        $policy->method('isToolAllowed')->willReturn(true);
+        $policy->method('isReadOnly')->willReturn(false);
+        $policy->method('resourcesEnabled')->willReturn(false);
+        $policy->method('promptsEnabled')->willReturn(false);
+
+        return new RpcService(
+            $this->createMock(RestClient::class),
+            new CacheService(new SimpleArrayCache()),
+            $policy,
+            $this->createMock(LoggerInterface::class),
+            new ToolRegistry(),
+            new SchemaValidator(),
+            new PromptRegistry()
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $response
+     * @return array<string, mixed>
+     */
+    private function toolResult(array $response): array
+    {
+        $this->assertArrayHasKey('result', $response);
+        $this->assertArrayNotHasKey(
+            'isError',
+            $response['result'],
+            $response['result']['content'][0]['text'] ?? ''
+        );
+        $this->assertArrayHasKey('structuredContent', $response['result']);
+
+        return $response['result']['structuredContent'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $response
+     */
+    private function assertToolError(array $response, string $expectedMessage): void
+    {
+        $this->assertArrayHasKey('result', $response);
+        $this->assertTrue($response['result']['isError'] ?? false, 'Expected an error result');
+        $this->assertStringContainsString($expectedMessage, $response['result']['content'][0]['text']);
+    }
+
+    private function makeDir(string $path): void
+    {
+        if (!is_dir($path) && !mkdir($path, 0o777, true) && !is_dir($path)) {
+            $this->fail('Could not create test directory: ' . $path);
+        }
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $child = $path . '/' . $entry;
+            is_dir($child) ? $this->removeTree($child) : unlink($child);
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,12 @@ if (!defined('JPATH_SITE')) {
     define('JPATH_SITE', '/tmp/site');
 }
 
+// A real, writable directory: tests that exercise file operations (template
+// files, overrides) create and tear down their own trees underneath it.
+if (!defined('JPATH_ROOT')) {
+    define('JPATH_ROOT', sys_get_temp_dir() . '/com-mcpserver-tests-' . getmypid());
+}
+
 require __DIR__ . '/Stubs/joomla.php';
 
 $autoload = dirname(__DIR__) . '/admin/vendor/autoload.php';


### PR DESCRIPTION
## Summary
Prepares the v1.7.1 release: `update_template_file` can create a file in an existing directory, a missing parent directory is reported clearly, and the component landing page warns administrators to back up before connecting an LLM.
## Changes in this release
### Changed
- `update_template_file` now creates a file when it does not exist, provided its parent directory already does (for example a second layout in an existing override folder). The response reports `created`.
- A missing parent directory is now reported as "Directory does not exist" rather than implying a path-traversal attempt.
### Added
- Backup warning on the component landing page, reminding administrators to take a full backup and test with Read-Only Mode before connecting a write-capable LLM client.